### PR TITLE
Cancel action

### DIFF
--- a/src/Controller/Output.php
+++ b/src/Controller/Output.php
@@ -290,7 +290,8 @@ trait Output
      */
     protected function getContentType($format)
     {
-        if (\Jasny\str_contains($format, '/')) { // Already MIME
+        // Check if it's already MIME
+        if (\Jasny\str_contains($format, '/')) {
             return $format;
         }
         

--- a/src/Controller/Output.php
+++ b/src/Controller/Output.php
@@ -377,12 +377,12 @@ trait Output
     }
 
     /**
-     * Output result
-     *
-     * @param mixed  $data
-     * @param string $format  Output format as MIME or extension
+     * Set the content type for the output
+     * 
+     * @param string $format
+     * @return string
      */
-    public function output($data, $format = null)
+    protected function outputContentType($format)
     {
         if (!isset($format)) {
             $contentType = $this->getResponse()->getHeaderLine('Content-Type');
@@ -396,6 +396,19 @@ trait Output
             $contentType = $this->getContentType($format);
             $this->setResponseHeader('Content-Type', $contentType);
         }
+        
+        return $contentType;
+    }
+    
+    /**
+     * Output result
+     *
+     * @param mixed  $data
+     * @param string $format  Output format as MIME or extension
+     */
+    public function output($data, $format = null)
+    {
+        $contentType = $this->outputContentType($format);
 
         try {
             $content = $this->serializeData($data, $contentType);

--- a/src/Controller/RouteAction.php
+++ b/src/Controller/RouteAction.php
@@ -11,6 +11,12 @@ use Psr\Http\Message\ResponseInterface;
 trait RouteAction
 {
     /**
+     * @var boolean
+     */
+    protected $actionCancelled = false;
+    
+    
+    /**
      * Get request, set for controller
      *
      * @return ServerRequestInterface
@@ -78,7 +84,6 @@ trait RouteAction
     
     /**
      * Called before executing the action.
-     * If the response is no longer a success statuc (>= 300), the action will not be executed.
      * 
      * <code>
      * protected function beforeAction()
@@ -91,8 +96,35 @@ trait RouteAction
      * }
      * </code>
      */
-    protected function beforeActionRun()
+    protected function before()
     {
+    }
+    
+    /**
+     * Called before executing the action.
+     */
+    protected function after()
+    {
+    }
+    
+    /**
+     * Cancel the action
+     * 
+     * @return boolean
+     */
+    public function cancel()
+    {
+        $this->actionCancelled = true;
+    }
+
+    /**
+     * Check if the action is cancelled
+     * 
+     * @return boolean
+     */
+    public function isCancelled()
+    {
+        return $this->actionCancelled;
     }
     
     /**
@@ -109,14 +141,16 @@ trait RouteAction
             return $this->notFound();
         }
 
-        $this->beforeActionRun();
+        $this->before();
         
-        if ($this->isSuccessful()) {
+        if (!$this->isCancelled()) {
             $args = isset($route->args) ? $route->args
                 : $this->getFunctionArgs($route, new \ReflectionMethod($this, $method)); 
 
             call_user_func_array([$this, $method], $args);
         }
+        
+        $this->after();
     }
 
     /**
@@ -151,3 +185,4 @@ trait RouteAction
         return $args;
     }
 }
+

--- a/src/Controller/RouteAction.php
+++ b/src/Controller/RouteAction.php
@@ -104,8 +104,6 @@ trait RouteAction
     
     /**
      * Cancel the action
-     * 
-     * @return boolean
      */
     public function cancel()
     {
@@ -151,7 +149,7 @@ trait RouteAction
     /**
      * Get the arguments for a function from a route using reflection
      * 
-     * @param object $route
+     * @param \stdClass                   $route
      * @param \ReflectionFunctionAbstract $refl
      * @return array
      */

--- a/src/Controller/RouteAction.php
+++ b/src/Controller/RouteAction.php
@@ -77,6 +77,7 @@ trait RouteAction
     
     /**
      * Called before executing the action.
+     * @codeCoverageIgnore
      * 
      * <code>
      * protected function beforeAction()
@@ -95,6 +96,7 @@ trait RouteAction
     
     /**
      * Called before executing the action.
+     * @codeCoverageIgnore
      */
     protected function after()
     {

--- a/src/Controller/RouteAction.php
+++ b/src/Controller/RouteAction.php
@@ -37,15 +37,8 @@ trait RouteAction
      * @param int    $code     HTTP status code
      */
     abstract public function notFound($message = '', $code = 404);
+    
 
-    /**
-     * Check if response is 2xx succesful, or empty
-     * 
-     * @return boolean
-     */
-    abstract public function isSuccessful();
-    
-    
     /**
      * Get the route
      * 

--- a/src/Controller/Session/Flash.php
+++ b/src/Controller/Session/Flash.php
@@ -8,7 +8,7 @@ namespace Jasny\Controller\Session;
 class Flash
 {
     /**
-     * @var array
+     * @var array|null
      */
     protected $data;
     

--- a/src/Controller/View/Twig.php
+++ b/src/Controller/View/Twig.php
@@ -18,6 +18,7 @@ trait Twig
 
     /**
      * Get server request
+     * 
      * @return ServerRequestInterface
      */
     abstract public function getRequest();
@@ -27,6 +28,7 @@ trait Twig
      *
      * @param mixed  $data
      * @param string $format  Output format as MIME or extension
+     * @return void
      */
     abstract public function output($data, $format = null);
 


### PR DESCRIPTION
Rather than checking the status, cancel an action with `cancel()`